### PR TITLE
Added Focus_Command state to LinkActionToolbar

### DIFF
--- a/packages/koenig-lexical/src/components/ui/LinkActionToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkActionToolbar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {$createRangeSelection, $getSelection, $setSelection} from 'lexical';
+import {$createRangeSelection, $getSelection, $setSelection, FOCUS_COMMAND} from 'lexical';
 import {LinkInput} from './LinkInput.jsx';
 import {TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -19,11 +19,19 @@ export function LinkActionToolbar({href, onClose, ...props}) {
             onClose();
         });
     };
+
+    const updateFocus = () => {
+        editor.dispatchCommand(FOCUS_COMMAND);
+    };
+
     return (
         <LinkInput
             cancel={onClose}
             href={href}
             update={onLinkUpdate}
+            onFocus={() => {
+                updateFocus();
+            }}
             {...props}
         />
     );

--- a/packages/koenig-lexical/src/components/ui/LinkInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInput.jsx
@@ -2,7 +2,7 @@ import CloseIcon from '../../assets/icons/kg-close.svg?react';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
-export function LinkInput({href, update, cancel, arrowStyles}) {
+export function LinkInput({href, update, cancel, arrowStyles, onFocus}) {
     const [_href, setHref] = React.useState(href);
 
     // add refs for input and container
@@ -56,6 +56,7 @@ export function LinkInput({href, update, cancel, arrowStyles}) {
                 data-testid="link-input"
                 placeholder="Enter url"
                 value={_href}
+                onFocus={onFocus}
                 onInput={(e) => {
                     setHref(e.target.value);
                 }}


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ADM-43/doesnt-work-in-link-modal-in-mini-koenig-editor

- Added an onFocus handler to the LinkActionToolbar so that we can follow the focus state elsewhere, including AdminX.